### PR TITLE
feat: implement update question method and endpoint

### DIFF
--- a/database/db_models.py
+++ b/database/db_models.py
@@ -72,6 +72,7 @@ class Question(Base):
     multiple_choices = Column(LONGTEXT, nullable=True)
     correct_answer = Column(LONGTEXT, nullable=True)
     is_accepted = Column(Boolean, nullable=True)
+    is_edited = Column(Boolean, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
      
     # Define the many-to-one relationship

--- a/handlers/question_handler.py
+++ b/handlers/question_handler.py
@@ -17,7 +17,7 @@ def get_quiz_questions(request: Request, quiz_id: str, db: Session):
     return JSONResponse(status_code=200, content={'data': {"questions": serialize_questions(questions)}})
 
 
-async def update_question(request: Request, db: Session):
+async def edit_question(request: Request, db: Session):
     user_id = request.state.user_id
     
     updated_question = await request.json()
@@ -37,6 +37,9 @@ async def update_question(request: Request, db: Session):
     # Update the question fields
     for field, value in updated_question.items():
         setattr(db_question, field, value)
+    
+    # Flag the question as edited for statistics
+    db_question.is_edited = True
     
     db.commit()
     

--- a/handlers/question_handler.py
+++ b/handlers/question_handler.py
@@ -1,10 +1,45 @@
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
+from fastapi import Request
 
-from database.db_models import Question
+from database.db_models import Question, Quiz
 from helpers.question_helpers import serialize_questions
+from starlette.exceptions import HTTPException
 
 
-def get_quiz_questions(quiz_id: str, db: Session):
+def get_quiz_questions(request: Request, quiz_id: str, db: Session):
+    user_id = request.state.user_id
+    quiz = db.query(Quiz).filter(Quiz.user_id == user_id).first()
+    if not quiz:
+        return HTTPException(status_code=404, detail='Quiz not found')
+    
     questions = db.query(Question).filter(Question.quiz_id == quiz_id, Question.is_accepted == True).all()
     return JSONResponse(status_code=200, content={'data': {"questions": serialize_questions(questions)}})
+
+
+async def update_question(request: Request, db: Session):
+    user_id = request.state.user_id
+    
+    updated_question = await request.json()
+    
+    query = (
+        db.query(Question)
+        .join(Quiz, Question.quiz_id == Quiz.quiz_id)
+        .filter(Question.question_id == updated_question.get('question_id'), Quiz.user_id == user_id)
+    )
+    
+    # Attempt to get the question
+    db_question = query.first()
+    
+    if not db_question:
+        raise HTTPException(status_code=404, detail="Question not found or you do not have permission to update it")
+    
+    # Update the question fields
+    for field, value in updated_question.items():
+        setattr(db_question, field, value)
+    
+    db.commit()
+    
+    return JSONResponse(status_code=200, content={'data': 'Update successful'})
+    
+    

--- a/main.py
+++ b/main.py
@@ -57,6 +57,6 @@ async def get_questions(request: Request, quiz_id: str, db: Session = Depends(ge
 
 
 @app.put('/questions')
-async def update_question(request: Request, db: Session = Depends(get_db)):
-    return await question_handler.update_question(request=request, db=db)
+async def edit_question(request: Request, db: Session = Depends(get_db)):
+    return await question_handler.edit_question(request=request, db=db)
 

--- a/main.py
+++ b/main.py
@@ -52,5 +52,11 @@ async def get_quiz(request: Request, quiz_id: str, db: Session = Depends(get_db)
 
 
 @app.get('/questions')
-async def get_questions(quiz_id: str, db: Session = Depends(get_db)):
-    return question_handler.get_quiz_questions(quiz_id=quiz_id, db=db)
+async def get_questions(request: Request, quiz_id: str, db: Session = Depends(get_db)):
+    return question_handler.get_quiz_questions(request=request, quiz_id=quiz_id, db=db)
+
+
+@app.put('/questions')
+async def update_question(request: Request, db: Session = Depends(get_db)):
+    return await question_handler.update_question(request=request, db=db)
+


### PR DESCRIPTION
### Description

This PR 

1. Improves the security of question getter method by ensuring the ownership
2. Implements the update question method. The question is also flagged as is_edited, which can be an important data point for my research

### Checklist

- [ ] I tested the implementation on Preview link and everything works as expected
- [ ] I fixed all the issues found by the linter
- [ ] I extended README / documentation, if necessary

### Screenshot (optional)
