### PR TITLE
feat: implement generate questions endpoint with mock data

### DIFF
--- a/handlers/question_handler.py
+++ b/handlers/question_handler.py
@@ -6,6 +6,7 @@ from database.db_models import Question, Quiz
 from helpers.question_helpers import serialize_questions
 from starlette.exceptions import HTTPException
 
+import time
 
 def get_quiz_questions(request: Request, quiz_id: str, db: Session):
     user_id = request.state.user_id
@@ -44,5 +45,51 @@ async def edit_question(request: Request, db: Session):
     db.commit()
     
     return JSONResponse(status_code=200, content={'data': 'Update successful'})
+    
+    
+async def generate_questions(request: Request, db: Session):
+    user_id = request.state.user_id
+    
+    question_generation_settings = await request.json()
+    amount = question_generation_settings.get('amount')
+    quiz_id= question_generation_settings.get('quiz_id')
+    instructions = question_generation_settings.get('instructions')
+    
+    # Add a check for ensuring the user is authorized to genreate questions 
+    # in this quiz. Ensure quiz ownership!
+        
+    if amount == None or quiz_id == None:
+        raise HTTPException(status_code=400, detail="Bad request. Check for amount and quiz id.")
+        
+    
+    questions = [
+    {
+        'question_text': 'Who was the king of France before the French Revolution?',
+        'correct_answer': 'Louis XVI',
+        'multiple_choices': 'Napoleon Bonaparte, Marie Antoinette, Maximilien Robespierre, Louis XVI',
+    },
+    {
+        'question_text': 'What event marked the beginning of the French Revolution in 1789?',
+        'correct_answer': 'The Storming of the Bastille',
+        'multiple_choices': 'The Reign of Terror, The Declaration of the Rights of Man, The Storming of the Bastille, The Tennis Court Oath',
+    },
+    {
+        'question_text': 'Which social class primarily led the French Revolution?',
+        'correct_answer': 'The Third Estate',
+        'multiple_choices': 'The First Estate, The Second Estate, The Third Estate, The Fourth Estate',
+    },
+    {
+        'question_text': 'Who wrote "The Rights of Man" during the French Revolution?',
+        'correct_answer': 'Thomas Paine',
+        'multiple_choices': 'Jean-Jacques Rousseau, Voltaire, Maximilien Robespierre, Thomas Paine',
+    },
+    {
+        'question_text': 'In which year did the French Revolution end?',
+        'correct_answer': '1799',
+        'multiple_choices': '1789, 1792, 1799, 1804',
+    },
+]
+    time.sleep(3)
+    return JSONResponse(status_code=200, content={'questions': questions})
     
     

--- a/main.py
+++ b/main.py
@@ -60,3 +60,7 @@ async def get_questions(request: Request, quiz_id: str, db: Session = Depends(ge
 async def edit_question(request: Request, db: Session = Depends(get_db)):
     return await question_handler.edit_question(request=request, db=db)
 
+
+@app.post('/questions')
+async def generate_questions(request: Request, db: Session = Depends(get_db)):
+    return await question_handler.generate_questions(request=request, db=db)


### PR DESCRIPTION
### Description

This PR adds a mock generate questions endpoint that validates request data and returns a hardcoded list of questions after a few seconds. 

### Checklist

- [ ] I tested the implementation on Preview link and everything works as expected
- [ ] I fixed all the issues found by the linter
- [ ] I extended README / documentation, if necessary

### Screenshot (optional)
